### PR TITLE
Add different levels of check

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,9 +17,23 @@ The tool will check the ``requirements.txt`` file, check packages and their
 dependencies and return an error if some packages are not compliant
 against the given strategy.
 
-A package is considered as not compliant when its license is in the unauthorized license list or is unknown.
-A package is considered as compliant when its license is in authorized license list, or if the package
-is in the list of authorized packages.
+The tool has 3 levels of checks to select from:
+
+Standard (default):
+    A package is considered as compliant when at least one of its licenses is
+    in the authorized license list, or if the package is in the list of
+    authorized packages.
+
+Cautious:
+    Same as *Standard*, but a package is **not** considered compliant when one
+    or more of its licenses is in the unauthorized license list, even if it
+    also has a license in the authorized license list. A package is still
+    compliant if present in the authorized packages list.
+
+Paranoid:
+    All licenses listed for a package must be in the authorised license list
+    for the package to be considered compliant. A package is still
+    compliant if present in the authorized packages list.
 
 How to install
 ==============

--- a/liccheck/command_line.py
+++ b/liccheck/command_line.py
@@ -23,9 +23,10 @@ except ImportError:
 
 
 class Strategy:
-    AUTHORIZED_LICENSES = []
-    UNAUTHORIZED_LICENSES = []
-    AUTHORIZED_PACKAGES = []
+    def __init__(self):
+        self.AUTHORIZED_LICENSES = []
+        self.UNAUTHORIZED_LICENSES = []
+        self.AUTHORIZED_PACKAGES = []
 
 
 class Reason(enum.Enum):

--- a/liccheck/command_line.py
+++ b/liccheck/command_line.py
@@ -7,6 +7,7 @@ except ImportError:
 import enum
 import functools
 import re
+import textwrap
 import sys
 
 import pkg_resources
@@ -27,6 +28,23 @@ class Strategy:
         self.AUTHORIZED_LICENSES = []
         self.UNAUTHORIZED_LICENSES = []
         self.AUTHORIZED_PACKAGES = []
+
+
+class Level(enum.Enum):
+    STANDARD = 'STANDARD'
+    CAUTIOUS = 'CAUTIOUS'
+    PARANOID = 'PARANOID'
+
+    @classmethod
+    def starting(cls, value):
+        """Return level starting with value (case-insensitive)"""
+        for member in cls:
+            if member.name.startswith(value.upper()):
+                return member
+        raise ValueError("No level starting with {!r}".format(value))
+
+    def __str__(self):
+        return self.name
 
 
 class Reason(enum.Enum):
@@ -76,7 +94,7 @@ def get_packages_info(requirement_file):
     return sorted(unique, key=(lambda item: item['name'].lower()))
 
 
-def check_package(strategy, pkg):
+def check_package(strategy, pkg, level=Level.STANDARD):
     whitelisted = (
             pkg['name'] in strategy.AUTHORIZED_PACKAGES and
             strategy.AUTHORIZED_PACKAGES[pkg['name']] == pkg['version']
@@ -85,14 +103,22 @@ def check_package(strategy, pkg):
         return Reason.OK
 
     at_least_one_unauthorized = False
+    count_authorized = 0
     for license in pkg['licenses']:
         lower = license.lower()
         if lower in strategy.UNAUTHORIZED_LICENSES:
             at_least_one_unauthorized = True
         if lower in strategy.AUTHORIZED_LICENSES:
-            return Reason.OK
+            count_authorized += 1
 
-    # if no license authorized but at least one unauthorized
+    if (count_authorized and level is Level.STANDARD) \
+            or (count_authorized and not at_least_one_unauthorized
+                and level is Level.CAUTIOUS) \
+            or (count_authorized and count_authorized == len(pkg['licenses'])
+                and level is Level.PARANOID):
+        return Reason.OK
+
+    # if not OK and at least one unauthorized
     if at_least_one_unauthorized:
         return Reason.UNAUTHORIZED
 
@@ -132,12 +158,13 @@ def group_by(items, key):
     return res
 
 
-def process(requirement_file, strategy):
+def process(requirement_file, strategy, level=Level.STANDARD):
     print('gathering licenses...')
     pkg_info = get_packages_info(requirement_file)
     all = list(pkg_info)
     print('{} package{} and dependencies.'.format(len(pkg_info), '' if len(pkg_info) <= 1 else 's'))
-    groups = group_by(pkg_info, functools.partial(check_package, strategy))
+    groups = group_by(
+        pkg_info, functools.partial(check_package, strategy, level=level))
     ret = 0
 
     def format(l):
@@ -175,16 +202,31 @@ def read_strategy(strategy_file):
 
 
 def parse_args(args):
-    parser = argparse.ArgumentParser(description='Check license of packages and there dependencies.')
-    parser.add_argument('-s', '--sfile', dest='strategy_ini_file', help='strategy ini file', required=True)
-    parser.add_argument('-r', '--rfile', dest='requirement_txt_file', help='path/to/requirement.txt file', nargs='?',
-                        default='./requirements.txt')
+    parser = argparse.ArgumentParser(
+        description='Check license of packages and there dependencies.',
+        formatter_class=argparse.RawTextHelpFormatter)
+    parser.add_argument(
+        '-s', '--sfile', dest='strategy_ini_file', help='strategy ini file',
+        required=True)
+    parser.add_argument(
+        '-l', '--level', choices=Level,
+        default=Level.STANDARD, type=Level.starting,
+        help=textwrap.dedent("""\
+            Level for testing compliance of packages, where:
+              Standard - At least one authorized license (default);
+              Cautious - Per standard but no unauthorized licenses;
+              Paranoid - All licenses must by authorized.
+        """))
+    parser.add_argument(
+        '-r', '--rfile', dest='requirement_txt_file',
+        help='path/to/requirement.txt file', nargs='?',
+        default='./requirements.txt')
     return parser.parse_args(args)
 
 
 def run(args):
     strategy = read_strategy(args.strategy_ini_file)
-    return process(args.requirement_txt_file, strategy)
+    return process(args.requirement_txt_file, strategy, args.level)
 
 
 def main():

--- a/liccheck/command_line.py
+++ b/liccheck/command_line.py
@@ -55,7 +55,9 @@ def get_packages_info(requirement_file):
     def get_license(dist):
         if dist.has_metadata(dist.PKG_INFO):
             metadata = dist.get_metadata(dist.PKG_INFO)
-            return [regex_license.search(metadata).group('license')]
+            license = regex_license.search(metadata).group('license')
+            if license != "UNKNOWN":  # Value when license not specified.
+                return [license]
 
         return []
 

--- a/tests/test_check_package.py
+++ b/tests/test_check_package.py
@@ -1,0 +1,60 @@
+import pytest
+
+from liccheck.command_line import check_package, Strategy, Reason, Level
+
+OK = Reason.OK
+UNAUTH = Reason.UNAUTHORIZED
+UNKNOWN = Reason.UNKNOWN
+
+
+@pytest.fixture('session')
+def strategy():
+    strategy = Strategy()
+    strategy.AUTHORIZED_LICENSES = ['authorized 1', 'authorized 2']
+    strategy.UNAUTHORIZED_LICENSES = ['unauthorized 1', 'unauthorized 2']
+    strategy.AUTHORIZED_PACKAGES = {'whitelisted': '1'}
+
+    return strategy
+
+
+@pytest.fixture('session')
+def packages():
+    return [
+        {
+            'name': 'auth_one', 'version': '1',
+            'licenses': ['authorized 1'],
+        }, {
+            'name': 'auth_one_and_two', 'version': '2',
+            'licenses': ['authorized 1', 'authorized 2'],
+        }, {
+            'name': 'auth_one_unauth_one', 'version': '1',
+            'licenses': ['authorized 1', 'unauthorized 1'],
+        }, {
+            'name': 'unauth_one', 'version': '2',
+            'licenses': ['unauthorized 1'],
+        }, {
+            'name': 'whitelisted', 'version': '1',
+            'licenses': ['unauthorized 1'],
+        }, {
+            'name': 'whitelisted', 'version': '2',
+            'licenses': ['unauthorized 1'],
+        }, {
+            'name': 'auth_one_unknown', 'version': '1',
+            'licenses': ['authorized 1', 'unknown'],
+        }, {
+            'name': 'unknown', 'version': '3',
+            'licenses': ['unknown'],
+        },
+    ]
+
+
+@pytest.mark.parametrize(
+    ('level', 'reasons'),
+    [(Level.STANDARD, [OK, OK, OK,     UNAUTH, OK, UNAUTH, OK,      UNKNOWN]),
+     (Level.CAUTIOUS, [OK, OK, UNAUTH, UNAUTH, OK, UNAUTH, OK,      UNKNOWN]),
+     (Level.PARANOID, [OK, OK, UNAUTH, UNAUTH, OK, UNAUTH, UNKNOWN, UNKNOWN]),
+     ],
+    ids=[level.name for level in Level])
+def test_check_package(strategy, packages, level, reasons):
+    for package, reason in zip(packages, reasons):
+        assert check_package(strategy, package, level) is reason

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,13 +1,15 @@
-from liccheck.command_line import parse_args, read_strategy, run
+from liccheck.command_line import parse_args, read_strategy, run, Level
 
 
 def test_parse_arguments():
     args = parse_args(['--sfile', 'my_strategy.ini'])
     assert args.strategy_ini_file == 'my_strategy.ini'
     assert args.requirement_txt_file == './requirements.txt'
-    args = parse_args(['--sfile', 'my_strategy.ini', '--rfile', 'my_requirements.txt'])
+    assert args.level is Level.STANDARD
+    args = parse_args(['--sfile', 'my_strategy.ini', '--rfile', 'my_requirements.txt', '--level', 'cautious'])
     assert args.strategy_ini_file == 'my_strategy.ini'
     assert args.requirement_txt_file == 'my_requirements.txt'
+    assert args.level is Level.CAUTIOUS
 
 
 def test_read_strategy():


### PR DESCRIPTION
* Standard (default): Current behaviour; at least one authorized license
* Cautious: Must be no unauthorized licenses
* Paranoid: All licenses found must be in authorized list