### PR TITLE
Don't crash on missing configuration keys

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,15 @@
+import os
+import tempfile
+
+import pytest
+
+
+@pytest.fixture
+def tmpfile():
+    fd, filepath = tempfile.mkstemp()
+    yield (os.fdopen(fd, "w"), filepath)
+    try:
+        os.close(fd)
+    except OSError:
+        pass  # It may already be closed
+    os.remove(filepath)

--- a/tests/test_check_package.py
+++ b/tests/test_check_package.py
@@ -1,9 +1,6 @@
-import os
-import tempfile
-
 import pytest
 
-from liccheck.command_line import check_package, Strategy, Reason, Level, get_packages_info
+from liccheck.command_line import check_package, Strategy, Reason, Level
 
 OK = Reason.OK
 UNAUTH = Reason.UNAUTHORIZED
@@ -61,20 +58,3 @@ def packages():
 def test_check_package(strategy, packages, level, reasons):
     for package, reason in zip(packages, reasons):
         assert check_package(strategy, package, level) is reason
-
-
-@pytest.fixture("session")
-def tmpfile():
-    fd, filepath = tempfile.mkstemp()
-    yield (os.fdopen(fd, "w"), filepath)
-    try:
-        os.close(fd)
-    except OSError:
-        pass # It may already be closed
-    os.remove(filepath)
-
-def test_license_strip(strategy, tmpfile):
-    tmpfh, tmppath = tmpfile
-    tmpfh.write("pip\n")
-    tmpfh.close()
-    assert get_packages_info(tmppath)[0]["licenses"] == ["MIT"]

--- a/tests/test_get_packages_info.py
+++ b/tests/test_get_packages_info.py
@@ -1,0 +1,10 @@
+import pytest
+
+from liccheck.command_line import get_packages_info
+
+
+def test_license_strip(tmpfile):
+    tmpfh, tmppath = tmpfile
+    tmpfh.write("pip\n")
+    tmpfh.close()
+    assert get_packages_info(tmppath)[0]["licenses"] == ["MIT"]

--- a/tests/test_read_strategy.py
+++ b/tests/test_read_strategy.py
@@ -1,0 +1,15 @@
+import pytest
+
+from liccheck.command_line import read_strategy
+
+
+def test_absent_sections(tmpfile):
+    tmpfh, tmppath = tmpfile
+    tmpfh.write("""
+[Licenses]
+""")
+    tmpfh.close()
+    strategy = read_strategy(tmppath)
+    assert strategy.AUTHORIZED_LICENSES == []
+    assert strategy.UNAUTHORIZED_LICENSES == []
+    assert strategy.AUTHORIZED_PACKAGES == {}


### PR DESCRIPTION
This branches contains two commits, one that reorganizes the tests to share the `tmpfile` fixture, and one that prevents crashes when the strategy file does not contain all expected keys.