### PR TITLE
remove argparse as a dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,12 +75,6 @@ setup(
     # this:
     #   py_modules=["my_module"],
 
-    # List run-time dependencies here.  These will be installed by pip when
-    # your project is installed. For an analysis of "install_requires" vs pip's
-    # requirements files see:
-    # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['argparse'],
-
     python_requires='>=2.7',
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,


### PR DESCRIPTION
Argparse is in the standard library from 2.6, so no need in install_requires if we already require python >=2.7. It's a totally useless dependency.