### PR TITLE
allow package to be excluded without version

### DIFF
--- a/liccheck/command_line.py
+++ b/liccheck/command_line.py
@@ -109,8 +109,10 @@ def get_packages_info(requirement_file):
 
 def check_package(strategy, pkg, level=Level.STANDARD):
     whitelisted = (
-            pkg['name'] in strategy.AUTHORIZED_PACKAGES and
-            strategy.AUTHORIZED_PACKAGES[pkg['name']] == pkg['version']
+            pkg['name'] in strategy.AUTHORIZED_PACKAGES and (
+                strategy.AUTHORIZED_PACKAGES[pkg['name']] == pkg['version']
+                or (level == Level.STANDARD and strategy.AUTHORIZED_PACKAGES[pkg['name']] == '')
+            )
     )
     if whitelisted:
         return Reason.OK


### PR DESCRIPTION
with this change we can exclude all versions of a package when liccheck is executed in STANDARD mode

```
[Authorized Packages]
    uWSGI:
```

My need is that I do have some packages that I do not distribute but use for development or tests. I cannot maintain an ever changing list of version for these packages. With this modification uWSGI can be updated, I do not care about its version and do not need to maintain it in my liccheck-strategy.ini file