### PR TITLE
Fix setup.py to install all dependencies from requirements.txt

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,9 @@ here = path.abspath(path.dirname(__file__))
 with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
+with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
+    install_reqs = f.read().splitlines()
+
 setup(
     name='liccheck',
 
@@ -76,6 +79,9 @@ setup(
     #   py_modules=["my_module"],
 
     python_requires='>=2.7',
+
+    install_requires=install_reqs,
+
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,
     # for example:


### PR DESCRIPTION
Pip/setuptools automatically install only dependencies listed in 'install_requires'
and 'extra_require' arguments of setup() function [1]. Commit #27 introduced
a new dependency 'semantic_version' which is not installed together with liccheck.

This patch updates setup.py to install all dependencies listed in requirements.txt

[1] https://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-dependencies

Steps to reproduce the issue:
$ cd python-license-check
$ virtualenv /tmp/bad-venv
$ /tmp/bad-venv/bin/pip install .
$ /tmp/bad-venv/bin/pip freeze
configparser==3.7.4
enum34==1.1.6
liccheck==0.3.10

Steps to verify (after the fix):
$ cd python-license-check
$ virtualenv /tmp/bad-venv
$ /tmp/bad-venv/bin/pip install .
$ /tmp/bad-venv/bin/pip freeze
configparser==3.7.4
enum34==1.1.6
liccheck==0.3.10
semantic-version==2.6.0

Note: for py36 the output differs by absence of enum34.