### PR TITLE
Read strategy from pyproject toml

### DIFF
--- a/liccheck/command_line.py
+++ b/liccheck/command_line.py
@@ -55,11 +55,11 @@ class Strategy:
         return strategy
 
     @classmethod
-    def from_config(cls, path):
+    def from_config(cls, strategy_file):
         config = ConfigParser()
         # keep case of options
         config.optionxform = str
-        config.read(path)
+        config.read(strategy_file)
 
         def get_config_list(section, option):
             try:
@@ -82,7 +82,6 @@ class Strategy:
             for name, value in config.items('Authorized Packages'):
                 strategy.AUTHORIZED_PACKAGES[name] = value
         return strategy
-
 
 
 class Level(enum.Enum):
@@ -266,7 +265,11 @@ def read_strategy(strategy_file=None):
     try:
         return Strategy.from_pyproject_toml()
     except NoValidConfigurationInPyprojectToml:
-        return Strategy.from_config(path=strategy_file)
+        pass
+    if strategy_file is None:
+        print("Need to either configure pyproject.toml or provide a strategy file", file=sys.stderr)
+        sys.exit(1)
+    return Strategy.from_config(strategy_file=strategy_file)
 
 
 def parse_args(args):

--- a/liccheck/command_line.py
+++ b/liccheck/command_line.py
@@ -270,7 +270,7 @@ def read_strategy(strategy_file=None):
     except NoValidConfigurationInPyprojectToml:
         pass
     if strategy_file is None:
-        print("Need to either configure pyproject.toml or provide a strategy file", file=sys.stderr)
+        print("Need to either configure pyproject.toml or provide a strategy file")
         sys.exit(1)
     return Strategy.from_config(strategy_file=strategy_file)
 

--- a/liccheck/command_line.py
+++ b/liccheck/command_line.py
@@ -47,9 +47,12 @@ class Strategy:
         except KeyError:
             raise NoValidConfigurationInPyprojectToml
 
+        def elements_to_lower_str(lst):
+            return [str(_).lower() for _ in lst]
+
         strategy = cls(
-            authorized_licenses=liccheck_section.get("authorized_licenses", []),
-            unauthorized_licenses=liccheck_section.get("unauthorized_licenses", []),
+            authorized_licenses=elements_to_lower_str(liccheck_section.get("authorized_licenses", [])),
+            unauthorized_licenses=elements_to_lower_str(liccheck_section.get("unauthorized_licenses", [])),
             authorized_packages=liccheck_section.get("authorized_packages", dict())
         )
         return strategy

--- a/liccheck/command_line.py
+++ b/liccheck/command_line.py
@@ -24,6 +24,11 @@ try:
 except ImportError:
     from pip.req import parse_requirements
 
+try:
+    FileNotFoundError
+except NameError:
+    FileNotFoundError = IOError
+
 
 class NoValidConfigurationInPyprojectToml(BaseException):
     pass

--- a/liccheck/command_line.py
+++ b/liccheck/command_line.py
@@ -25,6 +25,10 @@ except ImportError:
     from pip.req import parse_requirements
 
 
+class NoValidConfigurationInPyprojectToml(BaseException):
+    pass
+
+
 class Strategy:
     def __init__(self):
         self.AUTHORIZED_LICENSES = []
@@ -33,8 +37,19 @@ class Strategy:
 
     @classmethod
     def from_pyproject_toml(cls):
-        pyproject_toml = toml.load("pyproject.toml")
+        try:
+            pyproject_toml = toml.load("pyproject.toml")
+        except FileNotFoundError:
+            raise NoValidConfigurationInPyprojectToml
+
+        try:
+            liccheck_section = pyproject_toml["tool"]["liccheck"]
+        except KeyError:
+            raise NoValidConfigurationInPyprojectToml
+
         strategy = cls()
+        print(liccheck_section)
+        assert False
         return strategy
 
     @classmethod
@@ -242,7 +257,7 @@ def process(requirement_file, strategy, level=Level.STANDARD):
 def read_strategy(strategy_file=None):
     try:
         return Strategy.from_pyproject_toml()
-    except FileNotFoundError:
+    except NoValidConfigurationInPyprojectToml:
         return Strategy.from_config(path=strategy_file)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pip>=9.0.1
 enum34;python_version<"3.4"
 semantic_version
+toml

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ setup(
 
     python_requires='>=2.7',
 
-    install_requires=['semantic_version'],
+    install_requires=['semantic_version', 'toml'],
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
 pytest>=3.6.3
 python-openid;python_version<="2.7"
 python3-openid;python_version>="3.0"
+pytest-mock>=1.10

--- a/tests/test_check_package.py
+++ b/tests/test_check_package.py
@@ -9,11 +9,11 @@ UNKNOWN = Reason.UNKNOWN
 
 @pytest.fixture('session')
 def strategy():
-    strategy = Strategy()
-    strategy.AUTHORIZED_LICENSES = ['authorized 1', 'authorized 2']
-    strategy.UNAUTHORIZED_LICENSES = ['unauthorized 1', 'unauthorized 2']
-    strategy.AUTHORIZED_PACKAGES = {'whitelisted': '1'}
-
+    strategy = Strategy(
+        authorized_licenses=['authorized 1', 'authorized 2'],
+        unauthorized_licenses=['unauthorized 1', 'unauthorized 2'],
+        authorized_packages={'whitelisted': '1'}
+    )
     return strategy
 
 

--- a/tests/test_read_strategy.py
+++ b/tests/test_read_strategy.py
@@ -1,6 +1,4 @@
-import pytest
-
-from liccheck.command_line import read_strategy
+from liccheck.command_line import Strategy, read_strategy
 
 
 def test_absent_sections(tmpfile):
@@ -9,7 +7,13 @@ def test_absent_sections(tmpfile):
 [Licenses]
 """)
     tmpfh.close()
-    strategy = read_strategy(tmppath)
+    strategy = Strategy.from_config(path=tmppath)
     assert strategy.AUTHORIZED_LICENSES == []
     assert strategy.UNAUTHORIZED_LICENSES == []
     assert strategy.AUTHORIZED_PACKAGES == {}
+
+
+def test_falls_back_to_strategy_file_if_no_pyproject_toml(mocker):
+    from_strategy_mock = mocker.patch("liccheck.command_line.Strategy.from_config")
+    read_strategy("strategy_file")
+    from_strategy_mock.assert_called_once_with(path="strategy_file")

--- a/tests/test_read_strategy.py
+++ b/tests/test_read_strategy.py
@@ -9,8 +9,8 @@ class TestReadFromConfig:
     def test_absent_sections_in_config_file(self, tmpfile):
         tmpfh, tmppath = tmpfile
         tmpfh.write("""
-    [Licenses]
-    """)
+[Licenses]
+""")
         tmpfh.close()
         strategy = Strategy.from_config(strategy_file=tmppath)
         assert strategy.AUTHORIZED_LICENSES == []

--- a/tests/test_read_strategy.py
+++ b/tests/test_read_strategy.py
@@ -58,7 +58,7 @@ class TestReadFromPyprojectToml:
                 """
                 [tool.liccheck]
                 authorized_licenses = [
-                  "bsd",
+                  "BSD",
                   "new bsd",
                   "bsd license"
                 ]

--- a/tests/test_read_strategy.py
+++ b/tests/test_read_strategy.py
@@ -2,19 +2,19 @@ import os
 
 import pytest
 
-from liccheck.command_line import Strategy, read_strategy
+from liccheck.command_line import Strategy, NoValidConfigurationInPyprojectToml
+
 
 @pytest.fixture
 def empty_pyproject_toml_in_cwd(tmpdir):
     cwd = os.getcwd()
     os.chdir(tmpdir)
-    with open("pyproject.toml", "w") as file:
-        pass
+    open("pyproject.toml", "w").close()
     yield
     os.chdir(cwd)
 
 
-def test_absent_sections(tmpfile):
+def test_absent_sections_in_config_file(tmpfile):
     tmpfh, tmppath = tmpfile
     tmpfh.write("""
 [Licenses]
@@ -26,14 +26,12 @@ def test_absent_sections(tmpfile):
     assert strategy.AUTHORIZED_PACKAGES == {}
 
 
-def test_falls_back_to_strategy_file_if_no_pyproject_toml(mocker):
-    from_strategy_mock = mocker.patch("liccheck.command_line.Strategy.from_config")
-    read_strategy("strategy_file")
-    from_strategy_mock.assert_called_once_with(path="strategy_file")
+class TestReadFromPyprojectToml:
+    def test_raises_if_no_pyproject_toml(self):
+        with pytest.raises(NoValidConfigurationInPyprojectToml):
+            Strategy.from_pyproject_toml()
 
-
-@pytest.mark.usefixtures("empty_pyproject_toml_in_cwd")
-def test_falls_back_to_strategy_if_no_liccheck_section_in_pyproject_toml(mocker):
-    from_config_mock = mocker.patch("liccheck.command_line.Strategy.from_config")
-    read_strategy("strategy_file")
-    from_config_mock.assert_called_once_with(path="strategy_file")
+    @pytest.mark.usefixtures("empty_pyproject_toml_in_cwd")
+    def test_falls_back_to_strategy_if_no_liccheck_section_in_pyproject_toml(self, mocker):
+        with pytest.raises(NoValidConfigurationInPyprojectToml):
+            Strategy.from_pyproject_toml()

--- a/tests/test_read_strategy.py
+++ b/tests/test_read_strategy.py
@@ -46,7 +46,7 @@ class TestReadFromPyprojectToml:
     @pytest.fixture
     def empty_pyproject_toml_in_cwd(self, tmpdir):
         cwd = os.getcwd()
-        os.chdir(tmpdir)
+        os.chdir(str(tmpdir))
         open("pyproject.toml", "w").close()
         yield
         os.chdir(cwd)
@@ -84,8 +84,8 @@ class TestReadStrategy:
            read_strategy(strategy_file=None)
         assert exc.value.code == 1
         capture_result = capsys.readouterr()
-        _, err = capture_result
-        assert "Need to either configure pyproject.toml or provide a strategy file" in err.split("\n")
+        std, _ = capture_result
+        assert "Need to either configure pyproject.toml or provide a strategy file" in std.split("\n")
 
     @pytest.fixture
     def from_pyproject_toml_raising(self, mocker):

--- a/tests/test_read_strategy.py
+++ b/tests/test_read_strategy.py
@@ -5,15 +5,6 @@ import pytest
 from liccheck.command_line import Strategy, NoValidConfigurationInPyprojectToml
 
 
-@pytest.fixture
-def empty_pyproject_toml_in_cwd(tmpdir):
-    cwd = os.getcwd()
-    os.chdir(tmpdir)
-    open("pyproject.toml", "w").close()
-    yield
-    os.chdir(cwd)
-
-
 def test_absent_sections_in_config_file(tmpfile):
     tmpfh, tmppath = tmpfile
     tmpfh.write("""
@@ -32,6 +23,48 @@ class TestReadFromPyprojectToml:
             Strategy.from_pyproject_toml()
 
     @pytest.mark.usefixtures("empty_pyproject_toml_in_cwd")
-    def test_falls_back_to_strategy_if_no_liccheck_section_in_pyproject_toml(self, mocker):
+    def test_falls_back_to_strategy_if_no_liccheck_section_in_pyproject_toml(self):
         with pytest.raises(NoValidConfigurationInPyprojectToml):
             Strategy.from_pyproject_toml()
+
+    @pytest.mark.usefixtures("pyproject_toml_with_liccheck_section_in_cwd")
+    def test_with_liccheck_section_in_pyproject_toml(self):
+        strategy = Strategy.from_pyproject_toml()
+        assert strategy.AUTHORIZED_LICENSES == [
+            "bsd",
+            "new bsd",
+            "bsd license"
+        ]
+        assert strategy.UNAUTHORIZED_LICENSES == [
+            "gpl v3"
+        ]
+        assert strategy.AUTHORIZED_PACKAGES == {
+            "uuid": "1.30"
+        }
+
+    @pytest.fixture
+    def empty_pyproject_toml_in_cwd(self, tmpdir):
+        cwd = os.getcwd()
+        os.chdir(tmpdir)
+        open("pyproject.toml", "w").close()
+        yield
+        os.chdir(cwd)
+
+    @pytest.fixture
+    def pyproject_toml_with_liccheck_section_in_cwd(self, empty_pyproject_toml_in_cwd):
+        with open("pyproject.toml", "w") as file:
+            file.write(
+                """
+                [tool.liccheck]
+                authorized_licenses = [
+                  "bsd",
+                  "new bsd",
+                  "bsd license"
+                ]
+                unauthorized_licenses = [
+                  "gpl v3"
+                ]
+                [tool.liccheck.authorized_packages]
+                uuid = "1.30"
+                """
+            )

--- a/tests/test_read_strategy.py
+++ b/tests/test_read_strategy.py
@@ -1,4 +1,17 @@
+import os
+
+import pytest
+
 from liccheck.command_line import Strategy, read_strategy
+
+@pytest.fixture
+def empty_pyproject_toml_in_cwd(tmpdir):
+    cwd = os.getcwd()
+    os.chdir(tmpdir)
+    with open("pyproject.toml", "w") as file:
+        pass
+    yield
+    os.chdir(cwd)
 
 
 def test_absent_sections(tmpfile):
@@ -17,3 +30,10 @@ def test_falls_back_to_strategy_file_if_no_pyproject_toml(mocker):
     from_strategy_mock = mocker.patch("liccheck.command_line.Strategy.from_config")
     read_strategy("strategy_file")
     from_strategy_mock.assert_called_once_with(path="strategy_file")
+
+
+@pytest.mark.usefixtures("empty_pyproject_toml_in_cwd")
+def test_falls_back_to_strategy_if_no_liccheck_section_in_pyproject_toml(mocker):
+    from_config_mock = mocker.patch("liccheck.command_line.Strategy.from_config")
+    read_strategy("strategy_file")
+    from_config_mock.assert_called_once_with(path="strategy_file")


### PR DESCRIPTION
closes #31 

As proposed in #31 I added a capability to read the strategy from a `pyproject.toml` file. By default it looks for a `tool.liccheck` section in such a file. If this is not there, it falls back to the file passed in via the `-s` parameter. If this is not there either, an error message is shown.

A valid section in `pyproject.toml` would be

```toml
[tool.liccheck]
authorized_licenses = [
  "bsd",
  "new bsd",
  "bsd license"
]
unauthorized_licenses = [
  "gpl v3"
]

[tool.liccheck.authorized_packages]
uuid = "<=1.30"
```

What do you think about this approach? Should the `Strategy` parameter also be configurable by that way?

### Todo before merge
* [ ] Integration tests with `pyproject.toml`
* [ ] Documentation -> My proposal would be to make this the default way of configure this tool (and maybe deprecating reading from the config file)

But I wanted to get some feedback before doing this...