### PR TITLE
Use tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,44 @@
 language: python
-matrix:
-  include:
-    - python: "2.7"
-    - python: "3.5"
-    - python: "3.6"
-    - python: "3.7"
-    - python: "3.8"
-      dist: xenial
-      sudo: true
+python:
+  - "2.7"
+  - "3.5"
+  - "3.6"
+  - "3.7"
+  - "3.8"
+
+env:
+  jobs:
+    PYTEST_ADDOPTS="--strict --cov --cov-report=term-missing --cov-report=xml"
+
 install:
-- pip install -U pip setuptools wheel
-- pip install -r requirements.txt
-- pip install -r test-requirements.txt
+  - travis_retry pip install -U tox-travis pip setuptools wheel
+  - travis_retry pip install -r test-requirements.txt
+
 script:
-- python -m pytest tests
-deploy:
-  provider: pypi
-  skip_existing: true
-  user: Dev-Oss
-  password:
-    secure: AeTh3w8QeXQ6StzHlIbQcYZnr1qRjkQ4lBV0zup1t43dXxoRaXbQ7x2ZwcYpbM2h/lWeWssU2G6iY5ZW4a2t0+4go3PMPLSo2AC/sNJyVeuxvefkXTlWsL2YkTitpB1hhEzBVLMczNgf2OpLrmJIS/3hh1p3smiyj2xt1Jf7TaQ3bGneVFmlFrbOQTz5caoqjTRkhDWEa38pnSpbNIlgHIwhuDpVfUZn+Gh/UXmWdgiE1srpI1YLEMjpiFTe39Y36XvaJ/xszd/a929YgOalTZws+8iCzvI+/vSKdf1G+Phc4iVRbqwHAc4lfzbl42Yy81IMBrCMia/uum/lgkxZtcMJzyBwDXA0Rxtp1Ayh27bwI02tdJ3VQ8X8zvDJjATQhL2dRA5jqjNTco3SugM5rGcOvuLyjgROI9hQV0PSOXydqA/5kfLir5Y0cEpn5xW/RRVW5xgG9Pl6SzpS5vyd4/FB02wnp4pSxJM3v8WOUvMgKK4XjmMKKE8+IrY+avLLrhg3y3ziHdtjrnsVjo+fX+pdxymy85cNDVVH+AfBhG+Hnf2svxA4HnKzN9QaTGLB7EjU8TYCa1eJ8djSbEF9MStw2+b3cUG65jvWjDt/sPwzmcsrAob4rcy5pIBQbbtAa48lqighjjpM8EkDepLJaduDYUIbf3K+dKNjsKBXAo4=
-  on:
-    tags: true
+  - tox
+
+stages:
+  - test
+  - name: deploy
+    if: repo = dhatim/python-license-check AND tag IS present
+
+jobs:
+  include:
+    - stage: deploy
+      install: skip  # No need to install deps on deploy.
+      script: skip  # No test on the deploy stage.
+      after_success: true  # No need coverage
+      python: "3.8"
+      deploy:
+        provider: pypi
+        skip_existing: true
+        user: Dev-Oss
+        password:
+          secure: AeTh3w8QeXQ6StzHlIbQcYZnr1qRjkQ4lBV0zup1t43dXxoRaXbQ7x2ZwcYpbM2h/lWeWssU2G6iY5ZW4a2t0+4go3PMPLSo2AC/sNJyVeuxvefkXTlWsL2YkTitpB1hhEzBVLMczNgf2OpLrmJIS/3hh1p3smiyj2xt1Jf7TaQ3bGneVFmlFrbOQTz5caoqjTRkhDWEa38pnSpbNIlgHIwhuDpVfUZn+Gh/UXmWdgiE1srpI1YLEMjpiFTe39Y36XvaJ/xszd/a929YgOalTZws+8iCzvI+/vSKdf1G+Phc4iVRbqwHAc4lfzbl42Yy81IMBrCMia/uum/lgkxZtcMJzyBwDXA0Rxtp1Ayh27bwI02tdJ3VQ8X8zvDJjATQhL2dRA5jqjNTco3SugM5rGcOvuLyjgROI9hQV0PSOXydqA/5kfLir5Y0cEpn5xW/RRVW5xgG9Pl6SzpS5vyd4/FB02wnp4pSxJM3v8WOUvMgKK4XjmMKKE8+IrY+avLLrhg3y3ziHdtjrnsVjo+fX+pdxymy85cNDVVH+AfBhG+Hnf2svxA4HnKzN9QaTGLB7EjU8TYCa1eJ8djSbEF9MStw2+b3cUG65jvWjDt/sPwzmcsrAob4rcy5pIBQbbtAa48lqighjjpM8EkDepLJaduDYUIbf3K+dKNjsKBXAo4=
+        on:
+          tags: true
+          repo: dhatim/python-license-check
+
+after_success:
+  - travis_retry pip install codecov
+  - travis_retry codecov

--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,9 @@
     :target: https://badge.fury.io/py/liccheck
 .. image:: https://travis-ci.org/dhatim/python-license-check.svg?branch=master
     :target: https://travis-ci.org/dhatim/python-license-check
+.. image:: https://codecov.io/gh/dhatim/python-license-check/branch/master/graph/badge.svg
+    :target: https://codecov.io/gh/dhatim/python-license-check
+
 
 Python License Checker
 ======================
@@ -126,6 +129,14 @@ If some dependencies are unknown or are not matching the strategy, the output wi
 	    feedparser (5.2.1) : UNKNOWN []
 	      dependency:
 	          feedparser
+
+Contributing
+============
+
+To run the tests:
+::
+
+    $ tox -p all
 
 Licensing
 =========

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,11 @@
 [bdist_wheel]
 universal=0
+
+[coverage:run]
+branch = True
+source = .
+
+[coverage:report]
+include =
+    liccheck/*
+    tests/*

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,5 @@
--e .
 pytest>=3.6.3
+pytest-cov
 python-openid;python_version<="2.7"
 python3-openid;python_version>="3.0"
 pytest-mock>=1.10

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,13 @@
+[tox]
+envlist =
+    py{27,35,36,37,38}
+skip_missing_interpreters = True
+
+[testenv]
+deps =
+    -rtest-requirements.txt
+setenv =
+    cov: PYTEST_ADDOPTS=--strict --cov --cov-report=term-missing {env:PYTEST_ADDOPTS:}
+passenv =
+    PYTEST_*
+commands = pytest {posargs}


### PR DESCRIPTION
`tox` is a convenient way to run tests on multiple python versions. Also, it simplifies contributing to the project as the `tox --devenv -e py38 .venv` makes for easy environment setup.

What's included:
- run tests with tox
- revisit travis config to run tests with `tox-travis`
- run tests with coverage
- upload coverage reports to codecov.io
- add a badge to show coverage stats