### PR TITLE
__main__.py file

### DIFF
--- a/liccheck/__main__.py
+++ b/liccheck/__main__.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python
+
+from liccheck.command_line import main
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
In order to avoid `No module named liccheck.__main__; 'liccheck' is a package and cannot be directly executed`.