### PR TITLE
Build and distribute wheels

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             -   uses: actions/checkout@v2
-            -   name: build sdist
+            -   name: build sdist bdist_wheel
                 run: |
                     VERSION=${{ github.event.inputs.release_version }}
                     sed -i "s/version='.*'/version='$VERSION'/g" setup.py
@@ -41,7 +41,7 @@ jobs:
                     git push origin master
                     git tag $VERSION
                     git push origin $VERSION
-                    python setup.py sdist
+                    python setup.py sdist bdist_wheel
             -   name: deploy on pypi
                 uses: pypa/gh-action-pypi-publish@master
                 with:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bdist_wheel]
-universal=0
+universal = true
 
 [coverage:run]
 branch = True


### PR DESCRIPTION
This is a pure-python project so a universal wheel is possible. Github recommends against publishing wheels built by their pipelines, but that suggestion doesn't apply to universal wheels IMO.

Humorously, it would probably fix #67 since wheels don't have a `setup.py` that is invoked since they contain everything in a ready-to-go format.

I would still publish the sdist version even with a wheel as there are occasional scenarios where you either can't use wheels (even universal ones), or just want a quick way to examine the exact source code for a release.

That's basically what I hope I did on this PR, though unfortunately I don't know how to test the GH pipelines part. I did confirm that the `bdist_wheel` command spits out a universal wheel file.