### PR TITLE
Enable liccheck to be used as a pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+- id: liccheck
+  name: Run Python License Checker
+  description: Check license compliance of python requirements
+  entry: liccheck
+  args: []
+  language: python
+  files: ^(.*requirements.*\.txt|setup\.cfg|setup\.py|pyproject\.toml|liccheck\.ini)$


### PR DESCRIPTION
Fixes: #14
