### PR TITLE
Ignore editable requirements when parsing the req file

### DIFF
--- a/liccheck/requirements.py
+++ b/liccheck/requirements.py
@@ -25,6 +25,10 @@ def parse_requirements(requirement_file):
     for req in pip_parse_requirements(requirement_file, session=PipSession()):
         install_req = install_req_from_parsed_requirement(req)
         if install_req.markers and not pkg_resources.evaluate_marker(str(install_req.markers)):
+            # req should not installed due to env markers
+            continue
+        elif install_req.editable:
+            # skip editable req as they are failing in the resolve phase
             continue
         requirements.append(pkg_resources.Requirement.parse(str(install_req.req)))
     return requirements

--- a/tests/test_get_packages_info.py
+++ b/tests/test_get_packages_info.py
@@ -11,6 +11,7 @@ def test_license_strip(tmpfile):
     tmpfh.close()
     assert get_packages_info(tmppath)[0]["licenses"] == ["MIT"]
 
+
 def test_requirements_markers(tmpfile):
     tmpfh, tmppath = tmpfile
     tmpfh.write(
@@ -22,6 +23,19 @@ def test_requirements_markers(tmpfile):
         assert len(get_packages_info(tmppath)) == 2
     else:
         assert len(get_packages_info(tmppath)) == 1
+
+
+def test_editable_requirements_get_ignored(tmpfile):
+    tmpfh, tmppath = tmpfile
+    tmpfh.write(
+        "-e file:some_editable_req\n"
+        "pip\n"
+    )
+    tmpfh.close()
+
+    packages_info = get_packages_info(tmppath)
+    assert len(packages_info) == 1
+    assert packages_info[0]["name"] == "pip"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #74
Relates to #33

I suggest to ignore editable requirements, I don't see good reasons to not to so but if you want me to do things differently, just let me know. It is also possible to report the ignored packages on stdout if you believe that is useful.