### PR TITLE
feat: Analyze licenses `or`-ed together separately

### DIFF
--- a/liccheck/command_line.py
+++ b/liccheck/command_line.py
@@ -223,16 +223,16 @@ def check_package(strategy, pkg, level=Level.STANDARD, as_regex=False):
 
     at_least_one_unauthorized = False
     count_authorized = 0
-    for license in pkg["licenses"]:
-        lower = license.lower()
+    licenses = get_license_names(pkg["licenses"])
+    for license in licenses:
         if check_one(
-            lower,
+            license,
             license_rule="UNAUTHORIZED",
             as_regex=as_regex,
         ):
             at_least_one_unauthorized = True
         if check_one(
-            lower,
+            license,
             license_rule="AUTHORIZED",
             as_regex=as_regex,
         ):
@@ -247,7 +247,7 @@ def check_package(strategy, pkg, level=Level.STANDARD, as_regex=False):
         )
         or (
             count_authorized
-            and count_authorized == len(pkg["licenses"])
+            and count_authorized == len(licenses)
             and level is Level.PARANOID
         )
     ):
@@ -259,6 +259,14 @@ def check_package(strategy, pkg, level=Level.STANDARD, as_regex=False):
 
     return Reason.UNKNOWN
 
+def get_license_names(licenses):
+    names = []
+    for license in licenses:
+        license = license.lower()
+        options = license.split(" or ")
+        for option in options:
+            names.append(option)
+    return names
 
 def find_parents(package, all, seen):
     if package in seen:

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,3 +3,4 @@ pytest-cov
 python-openid;python_version<="2.7"
 python3-openid;python_version>="3.0"
 pytest-mock>=1.10
+tox

--- a/tests/test_check_package.py
+++ b/tests/test_check_package.py
@@ -26,6 +26,11 @@ def packages():
             "licenses": ["authorized 1", "unauthorized 1"],
         },
         {
+            "name": "auth_one_or_unauth_one",
+            "version": "2",
+            "licenses": ["authorized 1 or unauthorized 1"],
+        },
+        {
             "name": "unauth_one",
             "version": "2",
             "licenses": ["unauthorized 1"],
@@ -77,9 +82,9 @@ def packages():
 @pytest.mark.parametrize(
     ("level", "reasons"),
     [
-        (Level.STANDARD, [OK, OK, OK, UNAUTH, OK, UNAUTH, OK, UNKNOWN]),
-        (Level.CAUTIOUS, [OK, OK, UNAUTH, UNAUTH, OK, UNAUTH, OK, UNKNOWN]),
-        (Level.PARANOID, [OK, OK, UNAUTH, UNAUTH, OK, UNAUTH, UNKNOWN, UNKNOWN]),
+        (Level.STANDARD, [OK, OK, OK, OK, UNAUTH, OK, UNAUTH, OK, UNKNOWN]),
+        (Level.CAUTIOUS, [OK, OK, UNAUTH, UNAUTH, UNAUTH, OK, UNAUTH, OK, UNKNOWN]),
+        (Level.PARANOID, [OK, OK, UNAUTH, UNAUTH, UNAUTH, OK, UNAUTH, UNKNOWN, UNKNOWN]),
     ],
     ids=[level.name for level in Level],
 )


### PR DESCRIPTION
Multi-licensed packages may specify their allowed licenses using an `or`
designation.

This commit adds support for parsing out those `or`-ed licenses as if they had
been listed separately.

For example, the [pypdfium2](https://github.com/pypdfium2-team/pypdfium2) project uses the valid [SPDX](https://spdx.dev/) license identifier of [`Apache-2.0 OR BSD-3-Clause`](https://github.com/pypdfium2-team/pypdfium2/blob/5e669b8acf6c1a66a29a2cedbb6225012fc0e016/setup.cfg#L12).