### PR TITLE
fix: Limit multiple license splits to SPDX `OR`

### DIFF
--- a/liccheck/command_line.py
+++ b/liccheck/command_line.py
@@ -262,10 +262,9 @@ def check_package(strategy, pkg, level=Level.STANDARD, as_regex=False):
 def get_license_names(licenses):
     names = []
     for license in licenses:
-        license = license.lower()
-        options = license.split(" or ")
+        options = license.split(" OR ")
         for option in options:
-            names.append(option)
+            names.append(option.lower())
     return names
 
 def find_parents(package, all, seen):

--- a/liccheck/command_line.py
+++ b/liccheck/command_line.py
@@ -223,16 +223,16 @@ def check_package(strategy, pkg, level=Level.STANDARD, as_regex=False):
 
     at_least_one_unauthorized = False
     count_authorized = 0
-    for license in pkg["licenses"]:
-        lower = license.lower()
+    licenses = get_license_names(pkg["licenses"])
+    for license in licenses:
         if check_one(
-            lower,
+            license,
             license_rule="UNAUTHORIZED",
             as_regex=as_regex,
         ):
             at_least_one_unauthorized = True
         if check_one(
-            lower,
+            license,
             license_rule="AUTHORIZED",
             as_regex=as_regex,
         ):
@@ -247,7 +247,7 @@ def check_package(strategy, pkg, level=Level.STANDARD, as_regex=False):
         )
         or (
             count_authorized
-            and count_authorized == len(pkg["licenses"])
+            and count_authorized == len(licenses)
             and level is Level.PARANOID
         )
     ):
@@ -259,6 +259,14 @@ def check_package(strategy, pkg, level=Level.STANDARD, as_regex=False):
 
     return Reason.UNKNOWN
 
+def get_license_names(licenses):
+    names = []
+    for license in licenses:
+        license = license.lower()
+        options = license.split(" or ")
+        for option in options:
+            names.append(option)
+    return names
 
 def find_parents(package, all, seen):
     if package in seen:

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,3 +3,4 @@ pytest-cov
 python-openid;python_version<="2.7"
 python3-openid;python_version>="3.0"
 pytest-mock>=1.10
+tox

--- a/tests/test_check_package.py
+++ b/tests/test_check_package.py
@@ -26,6 +26,11 @@ def packages():
             "licenses": ["authorized 1", "unauthorized 1"],
         },
         {
+            "name": "auth_one_or_unauth_one",
+            "version": "2",
+            "licenses": ["authorized 1 or unauthorized 1"],
+        },
+        {
             "name": "unauth_one",
             "version": "2",
             "licenses": ["unauthorized 1"],
@@ -77,9 +82,9 @@ def packages():
 @pytest.mark.parametrize(
     ("level", "reasons"),
     [
-        (Level.STANDARD, [OK, OK, OK, UNAUTH, OK, UNAUTH, OK, UNKNOWN]),
-        (Level.CAUTIOUS, [OK, OK, UNAUTH, UNAUTH, OK, UNAUTH, OK, UNKNOWN]),
-        (Level.PARANOID, [OK, OK, UNAUTH, UNAUTH, OK, UNAUTH, UNKNOWN, UNKNOWN]),
+        (Level.STANDARD, [OK, OK, OK, OK, UNAUTH, OK, UNAUTH, OK, UNKNOWN]),
+        (Level.CAUTIOUS, [OK, OK, UNAUTH, UNAUTH, UNAUTH, OK, UNAUTH, OK, UNKNOWN]),
+        (Level.PARANOID, [OK, OK, UNAUTH, UNAUTH, UNAUTH, OK, UNAUTH, UNKNOWN, UNKNOWN]),
     ],
     ids=[level.name for level in Level],
 )

--- a/tests/test_check_package.py
+++ b/tests/test_check_package.py
@@ -28,7 +28,7 @@ def packages():
         {
             "name": "auth_one_or_unauth_one",
             "version": "2",
-            "licenses": ["authorized 1 or unauthorized 1"],
+            "licenses": ["authorized 1 OR unauthorized 1"],
         },
         {
             "name": "unauth_one",
@@ -57,6 +57,12 @@ def packages():
         },
     ]
 
+def strategy_with_one_auth(license):
+    return Strategy(
+        authorized_licenses=[license.lower()],
+        unauthorized_licenses=[],
+        authorized_packages={},
+    )
 
 @pytest.mark.parametrize(
     ("strategy_params", "as_regex"),
@@ -92,3 +98,33 @@ def test_check_package(strategy_params, packages, level, reasons, as_regex):
     strategy = Strategy(**strategy_params)
     for package, reason in zip(packages, reasons):
         assert check_package(strategy, package, level, as_regex) is reason
+
+@pytest.mark.parametrize(
+    "license", [
+        "GNU Library or Lesser General Public License (LGPL)",
+        "GNU Lesser General Public License v2 or later (LGPLv2+)"
+    ]
+)
+def test_check_package_respects_licences_with_a_lowercase_or(license):
+    strategy = strategy_with_one_auth(license)
+    package = {
+        "name": "lgpl_example",
+        "version": "2",
+        "licenses": [license],
+    }
+    assert check_package(strategy, package, Level.STANDARD, False) is OK
+
+def test_check_package_splits_licenses_with_SPDX_OR():
+    # The SPDX standard allows packages to specific dual licenses with an OR operator.
+    # See https://spdx.org/spdx-specification-21-web-version#h.jxpfx0ykyb60
+    mit_strategy = strategy_with_one_auth("MIT")
+    apache_strategy = strategy_with_one_auth("Apache-2.0")
+    gpl_strategy = strategy_with_one_auth("GPL-2.0-or-later")
+    package = {
+        "name": "mit_example",
+        "version": "2",
+        "licenses": ["MIT OR Apache-2.0"],
+    }
+    assert check_package(mit_strategy, package, Level.STANDARD, False) is OK
+    assert check_package(apache_strategy, package, Level.STANDARD, False) is OK
+    assert check_package(gpl_strategy, package, Level.STANDARD, False) is UNKNOWN


### PR DESCRIPTION
As mentioned in #100, many packages specify multiple valid licenses under which the project can be used via a single entry containing the license identifiers separated by the word `OR` (in line with the [SPDX specification](https://spdx.org/spdx-specification-21-web-version#h.jxpfx0ykyb60) for defining licenses).

The past implementation of `liccheck` could not understand these single entries which specified multiple valid licenses, which meant users of `liccheck` would have had to specify every possible combination of valid licenses to avoid false positives on licensing errors.

As discussed in #101, the implementation I provided in #100 was overly broad because it split licenses by the lowercase `or`, which breaks several licenses in the GPL family. By restricting the split to the uppercase `OR` from the SPDX specification we can retain the best of both worlds.

This PR includes additional unit tests to ensure this functionality behaves as expected.