### PR TITLE
Accept `License-Expression` in metadata (PEP 639)

### DIFF
--- a/liccheck/command_line.py
+++ b/liccheck/command_line.py
@@ -141,7 +141,7 @@ class Reason(enum.Enum):
 
 
 def get_packages_info(requirement_file, no_deps=False):
-    regex_license = re.compile(r"License: (?P<license>.*)?$", re.M)
+    regex_license = re.compile(r"License(?:-Expression)?: (?P<license>.*)?$", re.M)
     regex_classifier = re.compile(
         r"Classifier: License(?: :: OSI Approved)?(?: :: (?P<classifier>.*))?$", re.M
     )


### PR DESCRIPTION
[PEP 639](https://peps.python.org/pep-0639/) adds the `License-Expression` header. This commit adds support for it in the metadata parser.

Twisted 23.8.0 has already replaced the `Licence` header with `License-Expression` and thus is read as an `UNKNOWN` license.