### PR TITLE
Drop support for Python 2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
         runs-on: ubuntu-20.04
         strategy:
             matrix:
-                python-version: [ '2.7', '3.5', '3.6', '3.7', '3.8', '3.9', '3.10', '3.11' ]
+                python-version: [ '3.5', '3.6', '3.7', '3.8', '3.9', '3.10', '3.11' ]
         steps:
             -   uses: actions/checkout@v3
             -   name: set up Python ${{ matrix.python-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
         runs-on: ubuntu-20.04
         strategy:
             matrix:
-                python-version: [ '2.7', '3.5', '3.6', '3.7', '3.8', '3.9', '3.10', '3.11' ]
+                python-version: [ '3.5', '3.6', '3.7', '3.8', '3.9', '3.10', '3.11' ]
         steps:
             -   uses: actions/checkout@v3
             -   name: set up Python ${{ matrix.python-version }}

--- a/liccheck/command_line.py
+++ b/liccheck/command_line.py
@@ -4,10 +4,7 @@ import os.path
 
 from liccheck.requirements import parse_requirements, resolve, resolve_without_deps
 
-try:
-    from configparser import ConfigParser, NoOptionError
-except ImportError:
-    from ConfigParser import ConfigParser, NoOptionError
+from configparser import ConfigParser, NoOptionError
 import enum
 import functools
 import re

--- a/setup.py
+++ b/setup.py
@@ -56,8 +56,6 @@ setup(
 
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
@@ -76,23 +74,9 @@ setup(
     # this:
     #   py_modules=["my_module"],
 
-    python_requires='>=2.7',
+    python_requires='>=3.5',
 
     install_requires=['semantic_version>=2.7.0', 'toml'],
-
-    # List additional groups of dependencies here (e.g. development
-    # dependencies). You can install these using the following syntax,
-    # for example:
-    # $ pip install -e .[dev,test]
-    extras_require={
-        ':python_version < "3.4"': [
-            'ConfigParser',
-            'enum34',
-        ],
-        ':python_version >= "3.4"': [
-            'configparser',
-        ],
-    },
 
     # If there are data files included in your packages that need to be
     # installed, specify them here.  If using Python 2.6 or less, then these

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,5 @@
 pytest>=3.6.3
 pytest-cov
-python-openid;python_version<="2.7"
 python3-openid;python_version>="3.0"
 pytest-mock>=1.10
 tox

--- a/tests/test_get_packages_info.py
+++ b/tests/test_get_packages_info.py
@@ -15,14 +15,13 @@ def test_license_strip(tmpfile):
 def test_requirements_markers(tmpfile):
     tmpfh, tmppath = tmpfile
     tmpfh.write(
-        "python-openid;python_version<=\"2.7\"\n"
-        "python3-openid;python_version>=\"3.0\"\n"
+        "python3-openid;python_version>=\"3.9\"\n"
     )
     tmpfh.close()
-    if sys.version_info.major == 3:
+    if sys.version_info.minor >= 9:
         assert len(get_packages_info(tmppath)) == 2
     else:
-        assert len(get_packages_info(tmppath)) == 1
+        assert len(get_packages_info(tmppath)) == 0
 
 
 def test_editable_requirements_get_ignored(tmpfile):
@@ -42,11 +41,7 @@ def test_editable_requirements_get_ignored(tmpfile):
     ('no_deps', 'expected_packages'), (
         pytest.param(
             False,
-            ('configparser', 'liccheck', 'semantic-version', 'toml'),
-            marks=pytest.mark.skipif(
-                sys.version_info[0] < 3,
-                reason='with py2 there are more dependencies',
-            ),
+            ('liccheck', 'semantic-version', 'toml'),
             id='with deps'
         ),
         pytest.param(True, ('liccheck',), id='without deps'),

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,9 @@
 [tox]
-envlist = py27, py35, py36, py37, py38, py39, py310, py311
+envlist = py35, py36, py37, py38, py39, py310, py311
 skip_missing_interpreters = True
 
 [gh-actions]
 python =
-    2.7: py27
     3.5: py35
     3.6: py36
     3.7: py37


### PR DESCRIPTION
Github actions don't want to run on Python 2.7 anymore. This PR removes support for it. Feel free to drop it or merge it when you prefer, as it is more of a project decision to make.