### PR TITLE
change get_license priority

### DIFF
--- a/liccheck/command_line.py
+++ b/liccheck/command_line.py
@@ -146,7 +146,7 @@ def get_packages_info(requirement_file, no_deps=False):
     requirements = parse_requirements(requirement_file)
 
     def transform(dist):
-        licenses = get_licenses_from_classifiers(dist) or get_license(dist) or []
+        licenses = get_license(dist) or get_licenses_from_classifiers(dist) or []
         # Removing Trailing windows generated \r
         licenses = list(set([strip_license_for_windows(l) for l in licenses]))
         # Strip the useless "License" suffix and uniquify


### PR DESCRIPTION
I suppose licence of package should have more priority than Classifier licence.
In case, when we want to check `X Proprietary` licence in compliance pipeline and don’t want to check `Classifier: License :: Other/Proprietary License` globally from another package..
It’s related to [Issue 69](https://github.com/dhatim/python-license-check/issues/69).