### PR TITLE
feat: Add `as-regex` cli option

### DIFF
--- a/liccheck/command_line.py
+++ b/liccheck/command_line.py
@@ -432,6 +432,12 @@ def parse_args(args):
         help="don't check dependencies",
         action="store_true",
     )
+    parser.add_argument(
+        "--as-regex",
+        dest="as_regex",
+        help="enable regular expression matching for licenses",
+        action="store_true",
+    )
 
     return parser.parse_args(args)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,11 +12,13 @@ def test_parse_arguments():
     args = parse_args(['--sfile', 'my_strategy.ini'])
     assert args.strategy_ini_file == 'my_strategy.ini'
     assert args.requirement_txt_file == './requirements.txt'
+    assert args.as_regex is False
     assert args.level is Level.STANDARD
     assert args.no_deps is False
     args = parse_args(['--sfile', 'my_strategy.ini', '--rfile', 'my_requirements.txt', '--level', 'cautious'])
     assert args.strategy_ini_file == 'my_strategy.ini'
     assert args.requirement_txt_file == 'my_requirements.txt'
+    assert args.as_regex is False
     assert args.level is Level.CAUTIOUS
     assert args.no_deps is False
     args = parse_args(['--sfile', 'my_strategy.ini', '--rfile', 'my_requirements.txt', '--level', 'cautious', '--no-deps'])
@@ -24,7 +26,14 @@ def test_parse_arguments():
     assert args.requirement_txt_file == 'my_requirements.txt'
     assert args.level is Level.CAUTIOUS
     assert args.no_deps is True
+    assert args.as_regex is False
 
+    args = parse_args(["--sfile", "my_strategy.ini", "--as-regex"])
+    assert args.strategy_ini_file == "my_strategy.ini"
+    assert args.requirement_txt_file == "./requirements.txt"
+    assert args.level is Level.STANDARD
+    assert args.no_deps is False
+    assert args.as_regex is True
 
 def test_read_strategy():
     args = parse_args(['--sfile', 'liccheck.ini'])


### PR DESCRIPTION
Currently, the `as_regex` function can enabled when the user stores the configuration inside a `pyproject.toml`. With this feature, the user can set the parameter directly form the CLI.

Looking forward to your opinion @ochedru!